### PR TITLE
Default sensortype value does not match value used in template and js files

### DIFF
--- a/octoprint_Pinput_Shaping/__init__.py
+++ b/octoprint_Pinput_Shaping/__init__.py
@@ -94,7 +94,7 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
             "freqStart": 5,
             "freqEnd": 132,
             "dampingRatio": "0.05",
-            "sensorType": "adxl345spi"  
+            "sensorType": "adxlspi"  
         }    
 
 


### PR DESCRIPTION
jinja and js uses sensor type value of adxlspi but \_\_init\_\_.py sets the default as adxl345spi