### PR TITLE
Fix: logging error and make sensorType names more clear

### DIFF
--- a/octoprint_Pinput_Shaping/__init__.py
+++ b/octoprint_Pinput_Shaping/__init__.py
@@ -278,7 +278,6 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
                 self._identifier, dict(type="close_popup")
             )
             self.restore_shapers()
-            self._plugin_logger.info("Restored shaper values to printer.")
             return {
                 "success": True,
                 "summary": summary_line,
@@ -543,6 +542,7 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
                 cmd = f"M593 {axis} F{freq:.2f} D{damp} "
                 self._printer.commands(cmd)
                 self._plugin_logger.info(f"Restored: {cmd}")
+        self._plugin_logger.info("Restored shaper values to printer.")
 
     def get_input_shaping_results(self) -> dict:
         """Get the Input Shaping results after accelerometer capture."""
@@ -615,7 +615,6 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
         # self._plugin_logger.info(f"Sending plotly data to frontend: {json.dumps(data_for_plotly)}")
         self._plugin_manager.send_plugin_message(self._identifier, data_for_plotly)
         self.restore_shapers()
-        self._plugin_logger.info("Restored shaper values to printer.")
         return {"success": True}
 
     def _start_accelerometer_capture(self, freq=3200) -> None:

--- a/octoprint_Pinput_Shaping/templates/pinput_shaping_tab.jinja2
+++ b/octoprint_Pinput_Shaping/templates/pinput_shaping_tab.jinja2
@@ -245,7 +245,7 @@
   </div>
 
   <!-- Sensor Data Table -->
-  <table class="table table-striped table-bordered table-dark mt-3" data-bind="visible: hasData">
+  <table class="table table-bordered table-dark mt-3" data-bind="visible: hasData">
     <thead>
       <tr>
         <th>Time</th>
@@ -322,7 +322,7 @@
 
     <!-- Summary Table -->
     <div class="table-responsive mt-4" data-bind="visible: showResults">
-      <table class="table table-striped table-hover table-bordered align-middle">
+      <table class="table table-hover table-bordered align-middle">
         <thead class="table-dark text-center">
           <tr>
             <th>Shaper</th>

--- a/octoprint_Pinput_Shaping/templates/settings_pinput_shaping_settings.jinja2
+++ b/octoprint_Pinput_Shaping/templates/settings_pinput_shaping_settings.jinja2
@@ -170,24 +170,24 @@
     <div class="setting-title">Select Accelerometer Type</div>
     <div class="form-inline-group">
       <div class="form-inline-item">
-        <label for="adxlspi">ADXL345-SPI
+        <label for="adxl345-spi">ADXL345-SPI
           <i class="fas fa-info-circle" data-toggle="tooltip" title="SPI ADXL345, like Creality ones."></i>
         </label>
-        <input type="radio" name="sensorType" id="adxlspi" data-bind="checked: sensorType" value="adxlspi" checked>
+        <input type="radio" name="sensorType" id="adxl345-spi" data-bind="checked: sensorType" value="adxl345-spi" checked>
       </div>
 
       <div class="form-inline-item">
-        <label for="adxlusb">ADXL345-USB
+        <label for="adxl345-usb">ADXL345-USB
           <i class="fas fa-info-circle" data-toggle="tooltip" title="USB ADXL345, like BTT-ADXL345 or Fly-ADXL345."></i>
         </label>
-        <input type="radio" name="sensorType" id="adxlusb" data-bind="checked: sensorType" value="adxlusb">
+        <input type="radio" name="sensorType" id="adxl345-usb" data-bind="checked: sensorType" value="adxl345-usb">
       </div>
 
       <div class="form-inline-item">
         <label for="lis2dw">LIS2DW-USB
           <i class="fas fa-info-circle" data-toggle="tooltip" title="USB LIS2DW, like BTT-LIS2DW."></i>
         </label>
-        <input type="radio" name="sensorType" id="lis2dw" data-bind="checked: sensorType" value="lis2dw">
+        <input type="radio" name="sensorType" id="lis2dw-usb" data-bind="checked: sensorType" value="lis2dw-usb">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fix: If restoring shaper values fails it still logs as successful. Moved success log to the end of the restore_shapers function.
Renamed: SensorType names to be more clear. You will need to refresh browser after install and reselect sensor type in options.
Fix: Removed table-striping. If viewing in light mode you cant read every other row on the table. table-hover still whites out the hovered over selection in results. Might need some css to change colors.

![Screenshot at 2025-06-18 16-51-30](https://github.com/user-attachments/assets/0d7f559a-7f7a-4705-ac18-00f5cf46a163)
