### PR TITLE
Bugfix

### DIFF
--- a/octoprint_Pinput_Shaping/__init__.py
+++ b/octoprint_Pinput_Shaping/__init__.py
@@ -338,7 +338,7 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
         if printer_status == "OPERATIONAL":
             self._plugin_logger.info("Printer is idle. Proceeding with resonance test.")
             self.accelerometer_capture_active = True
-            self._plugin_logger.info("Backing up current shaper values...")
+            self._printer.commands("M117 Store shapers")
             self._printer.commands("M593")
             time.sleep(2)
             self._plugin_logger.info("Sending resonance test commands to printer...")
@@ -459,8 +459,8 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
     def gcode_received_handler(self, comm, line, *args, **kwargs) -> str:
         """Handle received G-code lines and process Input Shaping commands."""
 
-        if "Input Shaping:" in line:
-            self._plugin_logger.info("Detected: Input Shaping message")
+        if "Store shapers" in line:
+            self._plugin_logger.info("Detected M117: Store shapers message")
             self.getM593 = True
             self.shapers = {}
 

--- a/octoprint_Pinput_Shaping/__init__.py
+++ b/octoprint_Pinput_Shaping/__init__.py
@@ -278,7 +278,6 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
                 self._identifier, dict(type="close_popup")
             )
             self.restore_shapers()
-            self._plugin_logger.info("Restored shaper values to printer.")
             return {
                 "success": True,
                 "summary": summary_line,
@@ -543,6 +542,7 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
                 cmd = f"M593 {axis} F{freq:.2f} D{damp} "
                 self._printer.commands(cmd)
                 self._plugin_logger.info(f"Restored: {cmd}")
+        self._plugin_logger.info("Restored shaper values to printer.")
 
     def get_input_shaping_results(self) -> dict:
         """Get the Input Shaping results after accelerometer capture."""
@@ -615,7 +615,6 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
         # self._plugin_logger.info(f"Sending plotly data to frontend: {json.dumps(data_for_plotly)}")
         self._plugin_manager.send_plugin_message(self._identifier, data_for_plotly)
         self.restore_shapers()
-        self._plugin_logger.info("Restored shaper values to printer.")
         return {"success": True}
 
     def _start_accelerometer_capture(self, freq=3200) -> None:

--- a/octoprint_Pinput_Shaping/__init__.py
+++ b/octoprint_Pinput_Shaping/__init__.py
@@ -228,9 +228,6 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
         self._plugin_logger.info(f"Sensor type: {self._settings.get(['sensorType'])}")
 
         try:
-            self._plugin_logger.info("Backing up current shaper values...")
-            self._printer.commands("M593")
-            time.sleep(2)
             self.csv_filename = os.path.join(self.metadata_dir, "accelerometer_test_capture.csv")
             log_filename = os.path.join(self.metadata_dir, "accelerometer_output.log")
 
@@ -277,7 +274,6 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
             self._plugin_manager.send_plugin_message(
                 self._identifier, dict(type="close_popup")
             )
-            self.restore_shapers()
             return {
                 "success": True,
                 "summary": summary_line,
@@ -464,7 +460,7 @@ class PinputShapingPlugin(octoprint.plugin.StartupPlugin,
         """Handle received G-code lines and process Input Shaping commands."""
 
         if "Input Shaping:" in line:
-            self._plugin_logger.info("Detected M117: Input Shaping message")
+            self._plugin_logger.info("Detected: Input Shaping message")
             self.getM593 = True
             self.shapers = {}
 


### PR DESCRIPTION
Fix: "Restore Shaper Values" gets logged even if the event fails.
Fix: Don't restore shaper values when running the axis test.
Fix Shaper values are only being stored after plugin sees "Input Shaping:". Made a change to store on "Store shapers" instead.